### PR TITLE
Clarify error message

### DIFF
--- a/R/sfa_get_prices.R
+++ b/R/sfa_get_prices.R
@@ -27,7 +27,7 @@ sfa_get_prices_ <- function(
   # lapply necessary for SimFin+, where larger queries are possible
   DT_list <- lapply(content, function(x) {
     if (isFALSE(x[["found"]])) {
-      warning('No company found for ticker "', ticker, '".', call. = FALSE)
+      warning('No data returned. Please double-check your inputs.', call. = FALSE)
       return(NULL)
     }
     DT <- data.table::as.data.table(

--- a/R/sfa_get_shares.R
+++ b/R/sfa_get_shares.R
@@ -27,7 +27,7 @@ sfa_get_shares_ <- function(
   # lapply necessary for SimFin+, where larger queries are possible
   DT_list <- lapply(content, function(x) {
     if (isFALSE(x[["found"]])) {
-      warning('No company found for ticker "', ticker, '".', call. = FALSE)
+      warning('No data returned. Please double-check your inputs.', call. = FALSE)
       return(NULL)
     }
     DT <- as.data.table(

--- a/R/sfa_get_statement.R
+++ b/R/sfa_get_statement.R
@@ -40,7 +40,7 @@ sfa_get_statement_ <- function(
   # lapply necessary for SimFin+, where larger queries are possible
   DT_list <- lapply(content, function(x) {
     if (isFALSE(x[["found"]])) {
-      warning('No company found for ticker "', ticker, '".', call. = FALSE)
+      warning('No data returned. Please double-check your inputs.', call. = FALSE)
       return(NULL)
     }
     DT <- data.table::transpose(data.table::as.data.table(x[["data"]]))


### PR DESCRIPTION
Missing data can also be caused by year selection.

I got this warning because I asked for fiscal year 2021, which doesn't have data yet for TWLO. It was very confusing at first because the original warning seemed to imply that it was an invalid ticker, which is not the case.

I think this change will help people troubleshoot when no data is returned. 